### PR TITLE
Set CPU and disk size for EL9 templates

### DIFF
--- a/alma_9/vars.json
+++ b/alma_9/vars.json
@@ -1,4 +1,6 @@
 {
+    "cpu"          : "host",
+    "disk_size"    : "10000M",
     "iso_checksum" : "sha256:2a44e3f8a012c132da19b9aae2bf949e20b116f0a2a7ac3eca111972f4ac952f",
     "iso_url"      : "http://ord.mirror.rackspace.com/almalinux/9.1/isos/x86_64/AlmaLinux-9.1-x86_64-dvd.iso",
     "kickstart"    : "alma_9/kickstart.ks"

--- a/centos_stream_9/vars.json
+++ b/centos_stream_9/vars.json
@@ -1,4 +1,6 @@
 {
+    "cpu"          : "host",
+    "disk_size"    : "10000M",
     "iso_checksum" : "sha256:7791a00219db42d93c93303955ac6dd6204a6fbb86465eace0e091f9d817cdbf",
     "iso_url"      : "https://mirror.grid.uchicago.edu/pub/linux/centos-stream/9-stream/BaseOS/x86_64/iso/CentOS-Stream-9-20221129.1-x86_64-dvd1.iso",
     "kickstart"    : "centos_stream_9/kickstart.ks"

--- a/packer-qemu.json
+++ b/packer-qemu.json
@@ -1,5 +1,6 @@
 {
     "variables": {
+        "cpu"           : "qemu64",
         "disk_size"     : "6500M",
         "disk_image"    : "image.dsk",
         "iso_checksum"  : "",
@@ -35,6 +36,9 @@
             "memory"            : "{{ user `memory` }}",
             "net_device"        : "virtio-net",
             "output_directory"  : "{{ user `output_dir` }}",
+            "qemuargs"          : [
+                "-cpu", "{{ user `cpu` }}"
+            ],
             "shutdown_command"  : "shutdown -P now",
             "ssh_password"      : "{{ user `password` }}",
             "ssh_timeout"       : "30m",

--- a/rocky_9/vars.json
+++ b/rocky_9/vars.json
@@ -1,4 +1,6 @@
 {
+    "cpu"          : "host",
+    "disk_size"    : "10000M",
     "iso_checksum" : "sha256:69fa71d69a07c9d204da81767719a2af183d113bc87ee5f533f98a194a5a1f8a",
     "iso_url"      : "https://download.rockylinux.org/pub/rocky/9/isos/x86_64/Rocky-9.1-x86_64-dvd.iso",
     "kickstart"    : "rocky_9/kickstart.ks"


### PR DESCRIPTION
6.5 GB is apparently not enough, at least for Alma, so bump the disk. Also use a different CPU type to fix a kernel panic on startup as per https://www.reddit.com/r/CentOS/comments/srlq39/centos_stream_9_latest_image_broken/ this needs to be passed as a custom arg to qemu since there's not a first class way to do it in the packer plugin (https://developer.hashicorp.com/packer/plugins/builders/qemu).