### PR TITLE
fix a few deprecated kickstart options (SOFTWARE-5337)

### DIFF
--- a/alma_9/kickstart.ks
+++ b/alma_9/kickstart.ks
@@ -15,7 +15,10 @@ selinux --permissive
 services --enabled=NetworkManager,sshd
 skipx
 text
-timezone --utc --ntpservers ntp1.cs.wisc.edu,ntp2.cs.wisc.edu,ntp3.cs.wisc.edu America/Chicago
+timezone --utc America/Chicago
+timesource --ntp-server ntp1.cs.wisc.edu
+timesource --ntp-server ntp2.cs.wisc.edu
+timesource --ntp-server ntp3.cs.wisc.edu
 zerombr
 
 %packages --inst-langs=en_US.utf8 --excludedocs

--- a/alma_9/kickstart.ks
+++ b/alma_9/kickstart.ks
@@ -15,10 +15,10 @@ selinux --permissive
 services --enabled=NetworkManager,sshd
 skipx
 text
-timezone --isUtc --ntpservers ntp1.cs.wisc.edu,ntp2.cs.wisc.edu,ntp3.cs.wisc.edu America/Chicago
+timezone --utc --ntpservers ntp1.cs.wisc.edu,ntp2.cs.wisc.edu,ntp3.cs.wisc.edu America/Chicago
 zerombr
 
-%packages --instLangs=en_US.utf8 --excludedocs
+%packages --inst-langs=en_US.utf8 --excludedocs
 @core
 at
 bzip2

--- a/centos_stream_9/kickstart.ks
+++ b/centos_stream_9/kickstart.ks
@@ -22,7 +22,10 @@ selinux --permissive
 services --enabled=NetworkManager,sshd
 skipx
 text
-timezone --utc --ntpservers ntp1.cs.wisc.edu,ntp2.cs.wisc.edu,ntp3.cs.wisc.edu America/Chicago
+timezone --utc America/Chicago
+timesource --ntp-server ntp1.cs.wisc.edu
+timesource --ntp-server ntp2.cs.wisc.edu
+timesource --ntp-server ntp3.cs.wisc.edu
 zerombr
 
 %packages --inst-langs=en_US.utf8 --excludedocs

--- a/centos_stream_9/kickstart.ks
+++ b/centos_stream_9/kickstart.ks
@@ -22,10 +22,10 @@ selinux --permissive
 services --enabled=NetworkManager,sshd
 skipx
 text
-timezone --isUtc --ntpservers ntp1.cs.wisc.edu,ntp2.cs.wisc.edu,ntp3.cs.wisc.edu America/Chicago
+timezone --utc --ntpservers ntp1.cs.wisc.edu,ntp2.cs.wisc.edu,ntp3.cs.wisc.edu America/Chicago
 zerombr
 
-%packages --instLangs=en_US.utf8 --excludedocs
+%packages --inst-langs=en_US.utf8 --excludedocs
 @core
 at
 bzip2

--- a/packer-qemu.json
+++ b/packer-qemu.json
@@ -23,7 +23,7 @@
 
             "accelerator"       : "kvm",
             "boot_command"      : [
-                "<up><wait><tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{ user `kickstart` }}<enter><wait>"
+                "<up><wait><tab> text inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{ user `kickstart` }}<enter><wait>"
             ],
             "boot_wait"         : "10s",
             "disk_interface"    : "virtio",

--- a/rocky_9/kickstart.ks
+++ b/rocky_9/kickstart.ks
@@ -15,7 +15,10 @@ selinux --permissive
 services --enabled=NetworkManager,sshd
 skipx
 text
-timezone --utc --ntpservers ntp1.cs.wisc.edu,ntp2.cs.wisc.edu,ntp3.cs.wisc.edu America/Chicago
+timezone --utc America/Chicago
+timesource --ntp-server ntp1.cs.wisc.edu
+timesource --ntp-server ntp2.cs.wisc.edu
+timesource --ntp-server ntp3.cs.wisc.edu
 zerombr
 
 %packages --inst-langs=en_US.utf8 --excludedocs

--- a/rocky_9/kickstart.ks
+++ b/rocky_9/kickstart.ks
@@ -15,10 +15,10 @@ selinux --permissive
 services --enabled=NetworkManager,sshd
 skipx
 text
-timezone --isUtc --ntpservers ntp1.cs.wisc.edu,ntp2.cs.wisc.edu,ntp3.cs.wisc.edu America/Chicago
+timezone --utc --ntpservers ntp1.cs.wisc.edu,ntp2.cs.wisc.edu,ntp3.cs.wisc.edu America/Chicago
 zerombr
 
-%packages --instLangs=en_US.utf8 --excludedocs
+%packages --inst-langs=en_US.utf8 --excludedocs
 @core
 at
 bzip2


### PR DESCRIPTION
most important bit is the 'ks=' option went away entirely and got renamed to 'inst.ks=' ... which is why it was getting stuck in the GUI menu