### PR TITLE
more packer fixes (SOFTWARE-5337)

### DIFF
--- a/alma_9/kickstart.ks
+++ b/alma_9/kickstart.ks
@@ -42,4 +42,6 @@ yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarc
 yum -y distro-sync
 date > /etc/creation_date
 mkdir /mnt/user
+echo >> /etc/ssh/sshd_config
+echo PermitRootLogin yes >> /etc/ssh/sshd_config
 %end

--- a/centos_stream_9/kickstart.ks
+++ b/centos_stream_9/kickstart.ks
@@ -49,4 +49,6 @@ yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarc
 yum -y distro-sync
 date > /etc/creation_date
 mkdir /mnt/user
+echo >> /etc/ssh/sshd_config
+echo PermitRootLogin yes >> /etc/ssh/sshd_config
 %end

--- a/centos_stream_9/kickstart.ks
+++ b/centos_stream_9/kickstart.ks
@@ -10,13 +10,6 @@ keyboard us
 lang en_US.UTF-8
 network --bootproto dhcp
 reboot
-# Using external repos does not work on CentOS 8 for some reason; must get everything from the ISO.
-#repo --name=AppStream --baseurl=http://mirror.chtc.wisc.edu/centos/9/AppStream/x86_64/kickstart/
-#repo --name=BaseOS --baseurl http://mirror.chtc.wisc.edu/centos/9/BaseOS/x86_64/kickstart/
-#repo --name=extras --baseurl=http://mirror.chtc.wisc.edu/centos/9/extras/x86_64/kickstart/
-#repo --name=PowerTools --baseurl=http://mirror.chtc.wisc.edu/centos/9/PowerTools/x86_64/kickstart/
-#repo --name=epel --baseurl=http://mirror.chtc.wisc.edu/epel/9/x86_64/
-#url --url http://mirror.chtc.wisc.edu/centos/9/BaseOS/x86_64/kickstart/
 rootpw --iscrypted $1$22074107$h/Rm55DAZ37/ZhaVMPmFP/
 selinux --permissive
 services --enabled=NetworkManager,sshd

--- a/centos_stream_9/vars.json
+++ b/centos_stream_9/vars.json
@@ -1,7 +1,7 @@
 {
     "cpu"          : "host",
     "disk_size"    : "10000M",
-    "iso_checksum" : "sha256:7791a00219db42d93c93303955ac6dd6204a6fbb86465eace0e091f9d817cdbf",
-    "iso_url"      : "https://mirror.grid.uchicago.edu/pub/linux/centos-stream/9-stream/BaseOS/x86_64/iso/CentOS-Stream-9-20221129.1-x86_64-dvd1.iso",
+    "iso_checksum" : "sha256:93d7cf8ec497353fc1372c1bf01f2c8d42016a9dfb81b996722acf24f0d7c106",
+    "iso_url"      : "https://mirror.grid.uchicago.edu/pub/linux/centos-stream/9-stream/BaseOS/x86_64/iso/CentOS-Stream-9-20230109.0-x86_64-dvd1.iso",
     "kickstart"    : "centos_stream_9/kickstart.ks"
 }

--- a/packer-qemu.json
+++ b/packer-qemu.json
@@ -37,7 +37,7 @@
             "net_device"        : "virtio-net",
             "output_directory"  : "{{ user `output_dir` }}",
             "qemuargs"          : [
-                "-cpu", "{{ user `cpu` }}"
+                ["-cpu", "{{ user `cpu` }}"]
             ],
             "shutdown_command"  : "shutdown -P now",
             "ssh_password"      : "{{ user `password` }}",

--- a/rocky_9/kickstart.ks
+++ b/rocky_9/kickstart.ks
@@ -42,4 +42,6 @@ yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarc
 yum -y distro-sync
 date > /etc/creation_date
 mkdir /mnt/user
+echo >> /etc/ssh/sshd_config
+echo PermitRootLogin yes >> /etc/ssh/sshd_config
 %end

--- a/rpm/vmu-packer.spec
+++ b/rpm/vmu-packer.spec
@@ -1,6 +1,6 @@
 Summary: Scripts for using packer for making VMU images
 Name: vmu-packer
-Version: 1.7.1
+Version: 1.7.2
 Release: 1%{?dist}
 License: Apache 2.0
 Source0: %{name}-%{version}.tar.gz
@@ -31,6 +31,9 @@ echo '{"password":"ENTER PASSWORD HERE"}' > %{buildroot}/etc/%{name}/password.js
 %dir /var/log/%{name}
 
 %changelog
+* Tue Jan 10 2023 Carl Edquist <edquist@cs.wisc.edu> - 1.7.2-1
+- EL9 packer fixes (SOFTWARE-5337)
+
 * Mon Jan 09 2023 Carl Edquist <edquist@cs.wisc.edu> - 1.7.1-1
 - EL9 packer fixes (SOFTWARE-5337)
 


### PR DESCRIPTION
the `qemuargs` syntax thing was resulting in strange and inconsistent errors with the qemu command line, and the default for `PermitRootLogin` of `prohibit-password` was preventing ssh from connecting at the end of the build.

(I went off on a tangent thinking there was a more serious problem with the root password creation, because i wasn't able to log in as root with the password on the console, either.  Thought maybe it was a no-longer-supported version of the pw hash or something, because i was able to log in after changing the pw to `--plaintext` abc123.  Well, turned out the issue there were capital letters in the original pw and my vnc client was not sending capital letters with the shift key down (not that i could tell at the pw prompt), and even the capslock state on my local machine didn't match that of the one on the other side of vnc.  I guess capitals are hard over vnc.  Anyway wild goose chase but the rootpw itself turned out not to be the issue, it was just the sshd_config was blocking pw auth for root by default.)

I've confirmed that the alma 9 build works for me now!  (With any luck rocky and costream will, too.)