### PR TITLE
SOFTWARE-6279 decouple vars.json from rpm version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,18 +6,26 @@ NAME_VERSION := $(NAME)-$(VERSION)
 DATADIR := /usr/share/$(NAME)
 BINDIR := /usr/bin
 ETCDIR := /etc
+UNITDIR := /usr/lib/systemd/system
 
 SHELL:=bash
 
 
 .PHONY: install
-install: install-bin install-data
+install: install-bin install-data install-systemd
 
 
 .PHONY: install-bin
 install-bin:
 	mkdir -p $(DESTDIR)$(BINDIR)
-	install -D -p -m 755 vmu-rebuild-one vmu-rebuild-all packer_arm_substitute.py $(DESTDIR)$(BINDIR)
+	install -D -p -m 755 vmu-rebuild-one vmu-rebuild-all packer_arm_substitute.py vmu-packer-update $(DESTDIR)$(BINDIR)
+
+
+.PHONY: install-systemd
+install-systemd:
+	mkdir -p $(DESTDIR)$(UNITDIR)
+	install -p -m 644 systemd/vmu-packer-update.service systemd/vmu-packer-update.timer $(DESTDIR)$(UNITDIR)
+	install -p -m 644 systemd/vmu-packer.service systemd/vmu-packer.timer $(DESTDIR)$(UNITDIR)
 
 
 .PHONY: install-data

--- a/rpm/vmu-packer.spec
+++ b/rpm/vmu-packer.spec
@@ -1,12 +1,16 @@
 Summary: Scripts for using packer for making VMU images
 Name: vmu-packer
-Version: 1.16.4
+Version: 1.16.5
 Release: 1%{?dist}
 License: Apache 2.0
 Source0: %{name}-%{version}.tar.gz
 %ifarch x86_64
 Requires: packer-io
 %endif
+Requires: git
+Requires: make
+BuildRequires: systemd-rpm-macros
+%{?systemd_requires}
 BuildArch: noarch
 %define _debuginfo_subpackages %{nil}
 
@@ -24,16 +28,42 @@ make install DESTDIR=%{buildroot}
 mkdir -p %{buildroot}/var/log/%{name}
 echo '{"password":"ENTER PASSWORD HERE"}' > %{buildroot}/etc/%{name}/password.json
 
+%post
+%systemd_post vmu-packer-update.timer
+%systemd_post vmu-packer.timer
+
+%preun
+%systemd_preun vmu-packer-update.timer
+%systemd_preun vmu-packer.timer
+
+%postun
+%systemd_postun_with_restart vmu-packer-update.timer
+%systemd_postun_with_restart vmu-packer.timer
+
 %files
 /usr/bin/vmu-rebuild-one
 /usr/bin/vmu-rebuild-all
 /usr/bin/packer_arm_substitute.py
-/usr/share/%{name}
+/usr/bin/vmu-packer-update
+%{_unitdir}/vmu-packer-update.service
+%{_unitdir}/vmu-packer-update.timer
+%{_unitdir}/vmu-packer.service
+%{_unitdir}/vmu-packer.timer
+%dir /usr/share/%{name}
+/usr/share/%{name}/packer-qemu.json
+/usr/share/%{name}/files
+%config(noreplace) /usr/share/%{name}/*.x86_64
+%config(noreplace) /usr/share/%{name}/*.aarch64
 %attr(700,root,root) %dir /etc/%{name}
 %attr(600,root,root) %config(noreplace) /etc/%{name}/password.json
 %dir /var/log/%{name}
 
 %changelog
+* Mon Jul 20 2026 Matt Westphall <westphall@wisc.edu> - 1.16.5-1
+- Preserve locally modified per-arch template files (kickstart.ks, vars.json) on upgrade via %config(noreplace)
+- Add vmu-packer-update.timer, a systemd timer that daily at midnight refreshes /usr/share/vmu-packer/ from the upstream git repository
+- Add vmu-packer.timer, a systemd timer that runs vmu-rebuild-all once per week
+
 * Tue Jul 08 2026 Matt Westphall <westphall@wisc.edu> - 1.16.4-1
 - Update EL10 images to latest
     - AlmaLinux 10 to 10.2

--- a/rpm/vmu-packer.spec
+++ b/rpm/vmu-packer.spec
@@ -1,6 +1,6 @@
 Summary: Scripts for using packer for making VMU images
 Name: vmu-packer
-Version: 1.16.5
+Version: 1.17.0
 Release: 1%{?dist}
 License: Apache 2.0
 Source0: %{name}-%{version}.tar.gz

--- a/rpm/vmu-packer.spec
+++ b/rpm/vmu-packer.spec
@@ -59,7 +59,7 @@ echo '{"password":"ENTER PASSWORD HERE"}' > %{buildroot}/etc/%{name}/password.js
 %dir /var/log/%{name}
 
 %changelog
-* Mon Jul 20 2026 Matt Westphall <westphall@wisc.edu> - 1.16.5-1
+* Mon Jul 20 2026 Matt Westphall <westphall@wisc.edu> - 1.17.0-1
 - Preserve locally modified per-arch template files (kickstart.ks, vars.json) on upgrade via %config(noreplace)
 - Add vmu-packer-update.timer, a systemd timer that daily at midnight refreshes /usr/share/vmu-packer/ from the upstream git repository
 - Add vmu-packer.timer, a systemd timer that runs vmu-rebuild-all once per week

--- a/systemd/vmu-packer-update.service
+++ b/systemd/vmu-packer-update.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Update vmu-packer templates from upstream git repository
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/vmu-packer-update

--- a/systemd/vmu-packer-update.timer
+++ b/systemd/vmu-packer-update.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=Daily update of vmu-packer templates from upstream git repository
+
+[Timer]
+OnCalendar=*-*-* 00:00:00
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/systemd/vmu-packer.service
+++ b/systemd/vmu-packer.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=VMU Rebuild All
+After=network.target
+
+[Service]
+Type=oneshot
+User=root
+ExecStart=/usr/bin/vmu-rebuild-all
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd/vmu-packer.timer
+++ b/systemd/vmu-packer.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Run vmu-rebuild-all at 01:30 on Sunday
+
+[Timer]
+# Run 30 minutes into a new week
+OnCalendar=Sun *-*-* 00:30:00
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/vmu-packer-update
+++ b/vmu-packer-update
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -o pipefail
+set -o nounset
+
+REPO_URL=https://github.com/opensciencegrid/vmu-packer.git
+LOG_DIR=/var/log/vmu-packer
+LOG_FILE=$LOG_DIR/vmu-packer-update.log
+
+prog=${0##*/}
+
+fail () {
+    echo "$prog:" "$@" >&2
+    exit 1
+}
+
+[[ $(id -u) -eq 0 ]] || fail "Please run this script as root."
+
+mkdir -p "$LOG_DIR"
+
+workdir=$(mktemp -d)
+
+{
+    echo "$(date '+%F %T'): Updating /usr/share/vmu-packer from $REPO_URL"
+
+    git clone --depth 1 --quiet "$REPO_URL" "$workdir" \
+        || fail "Failed to clone $REPO_URL"
+
+    make -C "$workdir" install-data \
+        || fail "Failed to install updated templates from $workdir"
+
+    echo "$(date '+%F %T'): Update complete"
+} >> "$LOG_FILE" 2>&1

--- a/vmu-rebuild-all
+++ b/vmu-rebuild-all
@@ -3,10 +3,10 @@
 set -o pipefail
 set -o nounset
 
-TEMPLATES=(                rocky_8 alma_8
-           centos_stream_9 rocky_9 alma_9)
-           # centos_stream_9 rocky_9 alma_9
-           # gh_runner)
+TEMPLATES=(                 rocky_8  alma_8
+           centos_stream_9  rocky_9  alma_9
+           centos_stream_10 rocky_10 alma_10
+)
 
 DEPLOY_DIR=/staging/osg-images
 LOG_DIR=/var/log/vmu-packer


### PR DESCRIPTION
Various cleanups to the VMU packer install/update process to make future vars.json updates easier.
* Pulls in Joe's weekly rebuild systemd service into the RPM
* Adds another systemd service to periodically git pull the latest vars.json definitions from github
  * Un-hardcode vars.json definitions from RPM version 
* Adds missing EL10 config to the vmu-rebuild-all template list